### PR TITLE
adjustments following the directory structure changes in lz4 r125

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PACKAGES = build-essential subversion doxygen
 CHEADERS = $(wildcard *.h)
 CSOURCES = $(wildcard *.c)
 COBJECTS = $(patsubst %.c,%.o,$(CSOURCES))
-LIB_OBJECTS = $(filter-out yc.o yc-cnt.o,$(COBJECTS)) lz4/lz4.o
+LIB_OBJECTS = $(filter-out yc.o yc-cnt.o,$(COBJECTS)) lz4/lib/lz4.o
 
 all: lib $(EXE)
 lib: $(LIB)
@@ -26,7 +26,7 @@ lib: $(LIB)
 lz4:
 	svn checkout http://lz4.googlecode.com/svn/trunk/ lz4
 lz4/lz4.h lz4/lz4.c: lz4
-lz4/lz4.o: lz4/lz4.c
+lz4/lib/lz4.o: lz4/lib/lz4.c
 	$(CC) -std=c99 -O3 -Ilz4 -c -o $@ $<
 send.c recv.c: lz4/lz4.h
 

--- a/recv.c
+++ b/recv.c
@@ -1,7 +1,7 @@
 // (C) 2013 Cybozu et al.
 
 #include "yrmcds.h"
-#include "lz4/lz4.h"
+#include "lz4/lib/lz4.h"
 #include "portability.h"
 
 #include <errno.h>

--- a/send.c
+++ b/send.c
@@ -1,7 +1,7 @@
 // (C) 2013 Cybozu et al.
 
 #include "yrmcds.h"
-#include "lz4/lz4.h"
+#include "lz4/lib/lz4.h"
 #include "portability.h"
 
 #include <errno.h>


### PR DESCRIPTION
At Lz4 revision 125, the source files have moved into `lib/` directory.