### PR TITLE
suppress compiler warnings generated by clang

### DIFF
--- a/counter.c
+++ b/counter.c
@@ -267,8 +267,8 @@ yrmcds_cnt_recv(yrmcds_cnt* c, yrmcds_cnt_response* r) {
 
 static yrmcds_error
 send_command(yrmcds_cnt* c, yrmcds_cnt_command cmd, uint32_t* serial,
-             uint32_t body1_len, const char* body1,
-             uint32_t body2_len, const char* body2) {
+             size_t body1_len, const char* body1,
+             size_t body2_len, const char* body2) {
     if( c == NULL ||
         body1_len > UINT32_MAX - body2_len ||
         (body1_len != 0 && body1 == NULL) ||
@@ -290,7 +290,7 @@ send_command(yrmcds_cnt* c, yrmcds_cnt_command cmd, uint32_t* serial,
     header[1] = (uint8_t)cmd;
     header[2] = 0;
     header[3] = 0;
-    hton32(body1_len + body2_len, header + 4);
+    hton32((uint32_t)(body1_len + body2_len), header + 4);
     memcpy(header + 8, &c->serial, 4);
 
     yrmcds_error ret = YRMCDS_OK;
@@ -314,7 +314,7 @@ send_command(yrmcds_cnt* c, yrmcds_cnt_command cmd, uint32_t* serial,
 
     size_t i;
     for( i = 0; i < iovcnt; ) {
-        ssize_t n = writev(c->sock, iov + i, iovcnt - i);
+        ssize_t n = writev(c->sock, iov + i, (int)(iovcnt - i));
         if( n == -1 ) {
             if( errno == EINTR ) continue;
             ret = YRMCDS_SYSTEM_ERROR;

--- a/send.c
+++ b/send.c
@@ -34,7 +34,7 @@ static yrmcds_error send_command(
     size_t key_len, const char* key,
     size_t extras_len, const char* extras,
     size_t data_len, const char* data) {
-    if( cmd < 0 || cmd >= YRMCDS_CMD_BOTTOM ||
+    if( cmd >= YRMCDS_CMD_BOTTOM ||
         key_len > 65535 || extras_len > 127 || data_len > MAX_DATA_SIZE ||
         (key_len != 0 && key == NULL) ||
         (extras_len != 0 && extras == NULL) ||

--- a/send.c
+++ b/send.c
@@ -47,7 +47,7 @@ static yrmcds_error send_command(
     h[1] = (char)cmd;
     hton16((uint16_t)key_len, &h[2]);
     h[4] = (char)extras_len;
-    uint32_t total_len = key_len + extras_len + data_len;
+    uint32_t total_len = (uint32_t)(key_len + extras_len + data_len);
     hton32(total_len, &h[8]);
     hton64(cas, &h[16]);
 


### PR DESCRIPTION
The commits suppresses compiler warnings due to implicit conversions between integer types.

note: for some parts of 9a0a24f it might be better to return some kind of size error rather than just converting `size_t` to `uint32_t`