### PR TITLE
LZ4 separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,23 @@ PACKAGES = build-essential subversion doxygen
 CHEADERS = $(wildcard *.h)
 CSOURCES = $(wildcard *.c)
 COBJECTS = $(patsubst %.c,%.o,$(CSOURCES))
-LIB_OBJECTS = $(filter-out yc.o yc-cnt.o,$(COBJECTS)) lz4/lib/lz4.o
+LIB_OBJECTS = $(filter-out yc.o yc-cnt.o,$(COBJECTS))
 
 all: lib $(EXE)
 lib: $(LIB)
 
+# LZ4 is optional.  Run "make lz4; make" to build LZ4 enabled library.
 lz4:
 	svn checkout -r 127 http://lz4.googlecode.com/svn/trunk/ lz4
-lz4/lib/lz4.h lz4/lib/lz4.c: lz4
+
+ifeq ($(wildcard lz4), lz4)
+$(info LZ4 transparent compression is *enabled*)
+CPPFLAGS += -DLIBYRMCDS_USE_LZ4
+LZ4_CFLAGS = -std=c99 -O3
 lz4/lib/lz4.o: lz4/lib/lz4.c
-	$(CC) -std=c99 -O3 -Ilz4 -c -o $@ $<
-send.c recv.c: lz4/lib/lz4.h
+	$(CC) $(LZ4_CFLAGS) -Ilz4/lib -c -o $@ $<
+LIB_OBJECTS += lz4/lib/lz4.o
+endif
 
 yc: yc.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Build
 
 Just run `make`.
 
+To support [transparent LZ4 compression][compress], obtain LZ4 source
+code and rebuild the library as follows:
+
+```
+$ make lz4
+$ make clean; make
+```
+
 Install
 -------
 
@@ -64,3 +72,4 @@ Authors & Contributors
 [locking]: https://github.com/cybozu/yrmcds/blob/master/docs/locking.md
 [counter]: https://github.com/cybozu/yrmcds/blob/master/docs/counter.md
 [LZ4]: https://code.google.com/p/lz4/
+[compress]: USAGE.md#transparent-compression

--- a/USAGE.md
+++ b/USAGE.md
@@ -106,9 +106,20 @@ Transparent compression
 
 libyrmcds provides optional transparent data compression by [LZ4][].
 
-The feature is disabled by default.  To enable it, set compression
-threshold with `yrmcds_set_compression()`.  Note that all clients
-must enable the compression to properly handle compressed data.
+To use this feature, the library must be built with LZ4 as follows:
+
+```
+$ make lz4
+$ make
+```
+
+If the library supports LZ4 compression, you can enable transparent
+LZ4 (de)compression for large objects.  The threshold for compression
+can be set by `yrmcds_set_compression()`.  The compression is disabled
+by default.
+
+Note that all clients must support and enable the compression to
+properly handle compressed data.
 
 Counter extension
 -----------------

--- a/recv.c
+++ b/recv.c
@@ -1,8 +1,11 @@
 // (C) 2013 Cybozu et al.
 
 #include "yrmcds.h"
-#include "lz4/lib/lz4.h"
 #include "portability.h"
+
+#ifdef LIBYRMCDS_USE_LZ4
+#  include "lz4/lib/lz4.h"
+#endif
 
 #include <errno.h>
 #include <limits.h>
@@ -132,7 +135,10 @@ yrmcds_error yrmcds_recv(yrmcds* c, yrmcds_response* r) {
         return YRMCDS_OK;
     }
     r->value = 0;
+    r->data = data_len ? pdata : NULL;
+    r->data_len = data_len;
 
+#ifdef LIBYRMCDS_USE_LZ4
     if( c->compress_size && (r->flags & YRMCDS_FLAG_COMPRESS) ) {
         if( data_len == 0 ) {
             c->invalid = 1;
@@ -159,10 +165,9 @@ yrmcds_error yrmcds_recv(yrmcds* c, yrmcds_response* r) {
         }
         r->data = c->decompressed;
         r->data_len = decompress_size;
-    } else {
-        r->data = data_len ? pdata : NULL;
-        r->data_len = data_len;
     }
+#endif // LIBYRMCDS_USE_LZ4
+
     c->last_size = r->length;
     return YRMCDS_OK;
 }

--- a/send.c
+++ b/send.c
@@ -1,8 +1,11 @@
 // (C) 2013-2015 Cybozu et al.
 
 #include "yrmcds.h"
-#include "lz4/lib/lz4.h"
 #include "portability.h"
+
+#ifdef LIBYRMCDS_USE_LZ4
+#  include "lz4/lib/lz4.h"
+#endif
 
 #include <errno.h>
 #include <stdlib.h>
@@ -123,6 +126,7 @@ static yrmcds_error send_data(
         return YRMCDS_BAD_ARGUMENT;
 
     int compressed = 0;
+#ifdef LIBYRMCDS_USE_LZ4
     if( (c->compress_size > 0) && (data_len > c->compress_size) ) {
         if( flags & YRMCDS_FLAG_COMPRESS )
             return YRMCDS_BAD_ARGUMENT;
@@ -144,6 +148,7 @@ static yrmcds_error send_data(
         data = new_data;
         compressed = 1;
     }
+#endif // LIBYRMCDS_USE_LZ4
 
     char extras[8];
     hton32(flags, extras);

--- a/set_compression.c
+++ b/set_compression.c
@@ -1,10 +1,14 @@
-// (C) 2013 Cybozu.
+// (C) 2013-2015 Cybozu.
 
 #include "yrmcds.h"
 
 yrmcds_error yrmcds_set_compression(yrmcds* c, size_t threshold) {
+#ifdef LIBYRMCDS_USE_LZ4
     if( c == NULL )
         return YRMCDS_BAD_ARGUMENT;
     c->compress_size = threshold;
     return YRMCDS_OK;
+#else
+    return YRMCDS_NOT_IMPLEMENTED;
+#endif
 }

--- a/strerror.c
+++ b/strerror.c
@@ -1,4 +1,4 @@
-// (C) 2013 Cybozu.
+// (C) 2013-2015 Cybozu.
 
 #include "yrmcds.h"
 
@@ -22,6 +22,8 @@ const char* yrmcds_strerror(yrmcds_error e) {
         return "Failed to compress data";
     case YRMCDS_PROTOCOL_ERROR:
         return "Received malformed packet";
+    case YRMCDS_NOT_IMPLEMENTED:
+        return "Not implemented";
     default:
         return "Unknown error";
     };

--- a/yc.c
+++ b/yc.c
@@ -1,4 +1,4 @@
-// (C) 2013 Cybozu.
+// (C) 2013-2015 Cybozu.
 
 #include "yrmcds.h"
 
@@ -1015,9 +1015,10 @@ int main(int argc, char** argv) {
     yrmcds_error e = yrmcds_connect(s, server, port);
     CHECK_ERROR(e);
     e = yrmcds_set_compression(s, compression);
-    if( e != 0 )
+    if( e != 0 && e != YRMCDS_NOT_IMPLEMENTED ) {
         yrmcds_close(s);
-    CHECK_ERROR(e);
+        CHECK_ERROR(e);
+    }
 
     int ret = 1;
 #define do_cmd(name)                            \

--- a/yrmcds.h
+++ b/yrmcds.h
@@ -1,6 +1,6 @@
 /** @file yrmcds.h
  * libyrmcds public API.
- * (C) 2013 Cybozu.
+ * (C) 2013-2015 Cybozu.
  */
 
 #pragma once
@@ -143,6 +143,7 @@ typedef enum {
     YRMCDS_OUT_OF_MEMORY,     ///< malloc/realloc failed.
     YRMCDS_COMPRESS_FAILED,   ///< LZ4 compression failed.
     YRMCDS_PROTOCOL_ERROR,    ///< received malformed packet.
+    YRMCDS_NOT_IMPLEMENTED,   ///< the function is not available.
 } yrmcds_error;
 
 
@@ -200,6 +201,9 @@ yrmcds_error yrmcds_close(yrmcds* c);
  * is greater than 0.  If \p threshold is 0, then compression is disabled.
  *
  * The compression is disabled by default.
+ *
+ * If the library is built without LZ4, this function always return
+ * ::YRMCDS_NOT_IMPLEMENTED.
  *
  * Note that ::YRMCDS_FLAG_COMPRESS bit in the flags of compressed objects
  * will be used by the library iff the compression is enabled.


### PR DESCRIPTION
With these changes, libyrmcds gets separated from LZ4 cleanly, closes #6.