### PR TITLE
New macro LIBYRMCDS_NO_INTERNAL_LOCK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ PREFIX = /usr/local
 CC = gcc
 CXX = g++ -std=gnu++11
 CPPFLAGS = -D_GNU_SOURCE
+
+# Uncomment the next line to remove the internal lock used to
+# serialize sending commands.
+#
+#CPPFLAGS += -DLIBYRMCDS_NO_INTERNAL_LOCK
+
 OPTFLAGS = -gdwarf-3 -O2
 CFLAGS = -Wall -Wconversion $(OPTFLAGS)
 CXXFLAGS = $(CFLAGS) -Wnon-virtual-dtor -Woverloaded-virtual

--- a/close.c
+++ b/close.c
@@ -13,7 +13,9 @@ yrmcds_error yrmcds_close(yrmcds* c) {
 
     close(c->sock);
     c->sock = -1;
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     pthread_mutex_destroy(&(c->lock));
+#endif
     free(c->recvbuf);
     c->recvbuf = NULL;
     free(c->decompressed);

--- a/connect.c
+++ b/connect.c
@@ -124,11 +124,13 @@ static yrmcds_error connect_to_server(const char* node, uint16_t port, int* serv
 yrmcds_error yrmcds_connect(yrmcds* c, const char* node, uint16_t port) {
     if( c == NULL )
         return YRMCDS_BAD_ARGUMENT;
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     int e = pthread_mutex_init(&(c->lock), NULL);
     if( e != 0 ) {
         errno = e;
         return YRMCDS_SYSTEM_ERROR;
     }
+#endif // ! LIBYRMCDS_NO_INTERNAL_LOCK
     int server_fd;
     yrmcds_error err = connect_to_server(node, port, &server_fd);
     if( err != YRMCDS_OK )
@@ -139,7 +141,9 @@ yrmcds_error yrmcds_connect(yrmcds* c, const char* node, uint16_t port) {
     c->recvbuf = (char*)malloc(1 << 20);
     if( c->recvbuf == NULL ) {
         close(server_fd);
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
         pthread_mutex_destroy(&(c->lock));
+#endif
         return YRMCDS_OUT_OF_MEMORY;
     }
     c->capacity = 1 << 20;
@@ -153,11 +157,13 @@ yrmcds_error yrmcds_connect(yrmcds* c, const char* node, uint16_t port) {
 yrmcds_error yrmcds_cnt_connect(yrmcds_cnt* c, const char* node, uint16_t port) {
     if( c == NULL )
         return YRMCDS_BAD_ARGUMENT;
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     int e = pthread_mutex_init(&(c->lock), NULL);
     if( e != 0 ) {
         errno = e;
         return YRMCDS_SYSTEM_ERROR;
     }
+#endif // ! LIBYRMCDS_NO_INTERNAL_LOCK
     int server_fd;
     yrmcds_error err = connect_to_server(node, port, &server_fd);
     if( err != YRMCDS_OK )
@@ -167,7 +173,9 @@ yrmcds_error yrmcds_cnt_connect(yrmcds_cnt* c, const char* node, uint16_t port) 
     c->recvbuf = (char*)malloc(4096);
     if( c->recvbuf == NULL ) {
         close(server_fd);
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
         pthread_mutex_destroy(&(c->lock));
+#endif
         return YRMCDS_OUT_OF_MEMORY;
     }
     c->capacity = 4096;

--- a/counter.c
+++ b/counter.c
@@ -68,7 +68,9 @@ yrmcds_cnt_close(yrmcds_cnt* c) {
 
     close(c->sock);
     c->sock = -1;
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     pthread_mutex_destroy(&(c->lock));
+#endif
     free(c->recvbuf);
     c->recvbuf = NULL;
     free(c->stats.records);
@@ -273,11 +275,13 @@ send_command(yrmcds_cnt* c, yrmcds_cnt_command cmd, uint32_t* serial,
         (body2_len != 0 && body2 == NULL) )
         return YRMCDS_BAD_ARGUMENT;
 
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     int e = pthread_mutex_lock(&c->lock);
     if( e != 0 ) {
         errno = e;
         return YRMCDS_SYSTEM_ERROR;
     }
+#endif // ! LIBYRMCDS_NO_INTERNAL_LOCK
 
     c->serial += 1;
     if( serial != NULL )
@@ -330,7 +334,9 @@ send_command(yrmcds_cnt* c, yrmcds_cnt_command cmd, uint32_t* serial,
         }
     }
 
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     pthread_mutex_unlock(&c->lock);
+#endif
     return ret;
 }
 

--- a/send.c
+++ b/send.c
@@ -54,11 +54,13 @@ static yrmcds_error send_command(
     hton32((uint32_t)total_len, &h[8]);
     hton64(cas, &h[16]);
 
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     int e = pthread_mutex_lock(&c->lock);
     if( e != 0 ) {
         errno = e;
         return YRMCDS_SYSTEM_ERROR;
     }
+#endif // ! LIBYRMCDS_NO_INTERNAL_LOCK
 
     yrmcds_error ret = YRMCDS_OK;
     c->serial = c->serial + 1;
@@ -113,7 +115,9 @@ static yrmcds_error send_command(
     }
 
   OUT:
+#ifndef LIBYRMCDS_NO_INTERNAL_LOCK
     pthread_mutex_unlock(&c->lock);
+#endif
     return ret;
 }
 


### PR DESCRIPTION
If defined, the internal locks used to serialize sending commands
are removed.  This may (or may not) improve codes that acquire
locks externally.